### PR TITLE
replaced class with struct  in ixy project

### DIFF
--- a/app/Package.resolved
+++ b/app/Package.resolved
@@ -1,8 +1,0 @@
-{
-  "object": {
-    "pins": [
-
-    ]
-  },
-  "version": 1
-}

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/app/Sources/app/Subcommands/Forward.swift
+++ b/app/Sources/app/Subcommands/Forward.swift
@@ -55,18 +55,18 @@ class Forward: Subcommand {
 	// process/forward from -> to device using a specific queue (currently the queue is always 0)
 	private func process(from: Device, to: Device, queue: Int) {
 		// get queues
-		let rx = from.receiveQueues[queue]
-		let tx = to.transmitQueues[queue]
+		var rx = from.receiveQueues[queue]
+		var tx = to.transmitQueues[queue]
 
 		// receive packets
-		let packets = rx.fetchAvailablePackets(limit: batchSize)
+		var packets = rx.fetchAvailablePackets(limit: batchSize)
 		for packet in packets {
 			// touch each packet
 			packet.touch()
 		}
 
 		// transmit packets
-		let sentPackets = tx.transmit(packets, freeUnused: true)
+		let sentPackets = tx.transmit(&packets, freeUnused: true)
 
 		// keep track of lost packets due if not enough tx descriptors are available
 		lost += (packets.count - sentPackets)

--- a/app/Sources/app/Subcommands/PacketGen.swift
+++ b/app/Sources/app/Subcommands/PacketGen.swift
@@ -29,17 +29,19 @@ class PacketGen: Subcommand {
 
 	func loop() {
 		while(true) {
-			let packets = device.receiveQueues[0].fetchAvailablePackets()
+			var tmpReceiveQueue = device.receiveQueues[0]
+			let packets = tmpReceiveQueue.fetchAvailablePackets()
 
 			if packets.count > 0 {
 				Log.log("Got \(packets.count) packets", level: .info, component: "app")
 			}
 			
-			let tx = device.transmitQueues[0]
+			var tx = device.transmitQueues[0]
 			guard let packet = tx.createDummyPacket() else {
 				fatalError("no packet available")
 			}
-			_ = tx.transmit([packet])
+			var tmpPacket = [packet]
+			_ = tx.transmit(&tmpPacket)
 
 			sleep(1)
 		}

--- a/app/Sources/app/Subcommands/Simple.swift
+++ b/app/Sources/app/Subcommands/Simple.swift
@@ -30,7 +30,8 @@ class Simple: Subcommand {
 	func loop() {
 		nextTime = .now() + .seconds(1)
 		while(true) {
-			let packets = device.receiveQueues[0].fetchAvailablePackets()
+			var tmpReceiveQueue = device.receiveQueues[0]
+			var packets = tmpReceiveQueue.fetchAvailablePackets()
 
 			if packets.count > 0 {
 				Log.log("Got \(packets.count) packets", level: .info, component: "app")
@@ -40,7 +41,8 @@ class Simple: Subcommand {
 				}
 			}
 
-			_ = device.transmitQueues[0].transmit(packets)
+			var tmpTransmitQueue = device.transmitQueues[0]
+			_ = tmpTransmitQueue.transmit(&packets)
 
 			sleep(1)
 

--- a/ixy/Package.swift
+++ b/ixy/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/ixy/Sources/ixy/Common/Atomic.swift
+++ b/ixy/Sources/ixy/Common/Atomic.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Generic wrapper for accessing an object atomically
-public final class Atomic<T> {
+public struct Atomic<T> {
 	private let lock = DispatchSemaphore(value: 1)
 	private var _value: T
 
@@ -32,7 +32,7 @@ public final class Atomic<T> {
 	/// mutate the value suing a block
 	///
 	/// - Parameter transform: the block which can mutate the value
-	public func mutate(_ transform: (inout T) -> Void) {
+	public mutating func mutate(_ transform: (inout T) -> Void) {
 		lock.wait()
 		defer { lock.signal() }
 		transform(&_value)
@@ -41,7 +41,7 @@ public final class Atomic<T> {
 
 // MARK: - Extension for Strideable types, which offer the possibility to be incremented
 extension Atomic where T: Strideable {
-	public func increment(by: T.Stride = 1) -> T {
+	public mutating func increment(by: T.Stride = 1) -> T {
 		lock.wait()
 		defer { lock.signal() }
 		_value = _value.advanced(by: by)

--- a/ixy/Sources/ixy/Common/Extensions.swift
+++ b/ixy/Sources/ixy/Common/Extensions.swift
@@ -50,14 +50,14 @@ func throwsError(_ block: () throws -> Void) -> Error? {
 }
 
 // MARK: - extensions for pretty-printing integers
-public extension BinaryInteger {
+extension BinaryInteger {
 	/// print the integer like a pointer (0xff00aa)
-	public var pointerString: String {
+	var pointerString: String {
 		return "0x" + String(self, radix: 16, uppercase: false)
 	}
 
 	/// print the integer like a hexadecimal (ff00aa)
-	public var hexString: String {
+	var hexString: String {
 		return String(self, radix: 16, uppercase: false)
 	}
 }

--- a/ixy/Sources/ixy/Common/File.swift
+++ b/ixy/Sources/ixy/Common/File.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// a simple file wrapper class, which uses file descriptors to access the file
-internal class File {
+internal struct File {
 	internal var fd: Int32
 	internal var closeOnDealloc: Bool
 	internal var path: String?
@@ -33,11 +33,11 @@ internal class File {
 		self.path = path
 	}
 
-	deinit {
+	/*deinit {
 		if closeOnDealloc {
-			close(fd)
+			close(fd)//fixme: close file descriptor
 		}
-	}
+	}*/
 }
 
 // Read Support

--- a/ixy/Sources/ixy/Common/File.swift
+++ b/ixy/Sources/ixy/Common/File.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// a simple file wrapper class, which uses file descriptors to access the file
-internal struct File {
+internal struct File: ~Copyable {
 	internal var fd: Int32
 	internal var closeOnDealloc: Bool
 	internal var path: String?
@@ -20,24 +20,29 @@ internal struct File {
 		self.closeOnDealloc = closeOnDealloc
 	}
 
-	internal init(path: String, flags: Int32, createMode: mode_t? = nil) throws {
+	internal init(path: String, flags: Int32) throws {
 		guard let chars = path.cString(using: .utf8) else { throw FileError.internalError }
 		let pathPointer: UnsafePointer<CChar> = UnsafePointer(chars)
-		if let mode = createMode {
-			self.fd = open(pathPointer, flags, mode)
-		} else {
-			self.fd = open(pathPointer, flags)
-		}
-		guard self.fd >= 0 else { throw FileError.openError(errno) }
+		self.fd = open(pathPointer, flags)
+		//guard self.fd >= 0 else { throw FileError.openError(errno) }
 		self.closeOnDealloc = true
 		self.path = path
 	}
 
-	/*deinit {
+	internal init(path: String, flags: Int32, createMode: mode_t) throws {
+		guard let chars = path.cString(using: .utf8) else { throw FileError.internalError }
+		let pathPointer: UnsafePointer<CChar> = UnsafePointer(chars)
+		self.fd = open(pathPointer, flags, createMode)
+		//guard self.fd >= 0 else { throw FileError.openError(errno) }
+		self.closeOnDealloc = true
+		self.path = path
+	}
+
+	deinit {
 		if closeOnDealloc {
 			close(fd)//fixme: close file descriptor
 		}
-	}*/
+	}
 }
 
 // Read Support

--- a/ixy/Sources/ixy/Common/FixedStack.swift
+++ b/ixy/Sources/ixy/Common/FixedStack.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// a generic fixed stack implementation which can be used as a stand in for an array, to check performance
-class FixedStack<T> {
+struct FixedStack<T> {
 	var objects: [T?]
 	var top: Int = 0
 
@@ -22,19 +22,19 @@ class FixedStack<T> {
 		self.top = -1
 	}
 
-	func initialize(from objects: [T]) {
+	mutating func initialize(from objects: [T]) {
 		for object in objects {
 			self.push(object)
 		}
 	}
 
-	func push(_ object: T) {
+	mutating func push(_ object: T) {
 		assert(top < objects.count, "stack unbalanced push")
 		top += 1
 		objects[top] = object
 	}
 
-	func pop() -> T? {
+	mutating func pop() -> T? {
 		assert(top >= 0, "stack unbalanced pop")
 		let object = objects[top]
 		objects[top] = nil

--- a/ixy/Sources/ixy/Common/Log.swift
+++ b/ixy/Sources/ixy/Common/Log.swift
@@ -54,23 +54,23 @@ public struct Log {
 	}
 
 	internal static func log(_ message: @autoclosure () -> String, level: Level = .debug, component: Component) {
-		self.log(message, level: level, component: component.rawValue)
+		self.log(message(), level: level, component: component.rawValue)
 	}
 
 	internal static func error(_ message: @autoclosure () -> String, component: Component) {
-		log(message, level: .error, component: component)
+		log(message(), level: .error, component: component)
 	}
 
 	internal static func warn(_ message: @autoclosure () -> String, component: Component) {
-		log(message, level: .warn, component: component)
+		log(message(), level: .warn, component: component)
 	}
 
 	internal static func info(_ message: @autoclosure () -> String, component: Component) {
-		log(message, level: .info, component: component)
+		log(message(), level: .info, component: component)
 	}
 
 	internal static func debug(_ message: @autoclosure () -> String, component: Component) {
-		log(message, level: .debug, component: component)
+		log(message(), level: .debug, component: component)
 	}
 
 	internal static func formatComponent(_ component: String) -> String? {

--- a/ixy/Sources/ixy/Common/Log.swift
+++ b/ixy/Sources/ixy/Common/Log.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// basic logger with debug/info/warn/error levels and some components
-public final class Log {
+public struct Log {
 	static public var enableColors: Bool = true
 	static var componentLength: Int? = 6 {
 		didSet {

--- a/ixy/Sources/ixy/Common/Pagemap.swift
+++ b/ixy/Sources/ixy/Common/Pagemap.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// simple subclass for the pagemap file with easy initializiation based on Constants.pagemapPath and conversion
 /// from virtual to physical pointer
-struct Pagemap {
+struct Pagemap: ~Copyable {
 	let file: File
 	static var pagesize: UInt = {
 		return UInt(sysconf(Int32(_SC_PAGESIZE)))

--- a/ixy/Sources/ixy/Common/Pagemap.swift
+++ b/ixy/Sources/ixy/Common/Pagemap.swift
@@ -9,13 +9,15 @@ import Foundation
 
 /// simple subclass for the pagemap file with easy initializiation based on Constants.pagemapPath and conversion
 /// from virtual to physical pointer
-class Pagemap: File {
+struct Pagemap {
+	let file: File
 	static var pagesize: UInt = {
 		return UInt(sysconf(Int32(_SC_PAGESIZE)))
 	}()
 
 	init() throws {
-		try super.init(path: Constants.pagemapPath, flags: O_RDONLY)
+		try file = File(path: Constants.pagemapPath, flags: O_RDONLY)
+		//try super.init(path: Constants.pagemapPath, flags: O_RDONLY)
 	}
 
 	func physical(from virtual: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
@@ -23,7 +25,7 @@ class Pagemap: File {
 		// TODO: check if correct calculation due to possible precedence differences!
 		let offset: off_t = off_t(virtualIntAddress / Pagemap.pagesize * UInt(MemoryLayout<Int>.size))
 		do {
-			let pageNumber: UInt = try self.read(offset: offset)
+			let pageNumber: UInt = try file.read(offset: offset)
 			// TODO: check if correct calculation due to possible precedence differences!
 			let physicalIntAddress = ((pageNumber & 0x7f_ffff_ffff_ffff) * Pagemap.pagesize) + (virtualIntAddress % Pagemap.pagesize)
 			let physical = UnsafeMutableRawPointer(bitPattern: physicalIntAddress)

--- a/ixy/Sources/ixy/Device/Config/DeviceConfig.swift
+++ b/ixy/Sources/ixy/Device/Config/DeviceConfig.swift
@@ -8,18 +8,19 @@
 import Foundation
 
 /// simple wrapper class based on file for a pci device
-internal class DeviceConfig: File {
+internal struct DeviceConfig {
+	let file: File
 	internal init(address: PCIAddress) throws {
 		let path = address.path + "/config"
-		try super.init(path: path, flags: O_RDONLY)
+		try file = File(path: path, flags: O_RDONLY)
 	}
 
 	var vendorID: UInt16 {
-		return (try? self.read(offset: 0x00)) ?? 0
+		return (try? file.read(offset: 0x00)) ?? 0
 	}
 
 	var deviceID: UInt16 {
-		return (try? self.read(offset: 0x02)) ?? 0
+		return (try? file.read(offset: 0x02)) ?? 0
 	}
 
 	var classCode: UInt32 {
@@ -28,7 +29,7 @@ internal class DeviceConfig: File {
 			// Datasheet P755
 			// Register at 0x08 = [RevID:8][ClassCode:24]
 			// -> read from 0x08 but discard first 8 bits
-			try code = self.read(offset: 0x08)
+			try code = file.read(offset: 0x08)
 			code = ((code >> 8) & 0xFF_FFFF)
 		} catch {
 			code = 0

--- a/ixy/Sources/ixy/Device/Config/DeviceConfig.swift
+++ b/ixy/Sources/ixy/Device/Config/DeviceConfig.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// simple wrapper class based on file for a pci device
-internal struct DeviceConfig {
+internal struct DeviceConfig: ~Copyable {
 	let file: File
 	internal init(address: PCIAddress) throws {
 		let path = address.path + "/config"
@@ -36,10 +36,7 @@ internal struct DeviceConfig {
 		}
 		return code
 	}
-}
 
-// MARK: - CustomStringConvertible
-extension DeviceConfig: CustomStringConvertible {
 	var description: String {
 		let vendor = String(self.vendorID, radix: 16, uppercase: true)
 		let device = String(self.deviceID, radix: 16, uppercase: true)
@@ -47,4 +44,14 @@ extension DeviceConfig: CustomStringConvertible {
 		return "DeviceConfig(vendor=0x\(vendor), device=0x\(device), class=0x\(classC))"
 	}
 }
+
+// MARK: - CustomStringConvertible
+/*extension DeviceConfig: CustomStringConvertible {
+	var description: String {
+		let vendor = String(self.vendorID, radix: 16, uppercase: true)
+		let device = String(self.deviceID, radix: 16, uppercase: true)
+		let classC = String(self.classCode, radix: 16, uppercase: true)
+		return "DeviceConfig(vendor=0x\(vendor), device=0x\(device), class=0x\(classC))"
+	}
+}*/
 

--- a/ixy/Sources/ixy/Device/Device.swift
+++ b/ixy/Sources/ixy/Device/Device.swift
@@ -81,8 +81,9 @@ public struct Device {
 	private static func checkConfig(address: PCIAddress) throws {
 		// try to open device config
 		let config = try DeviceConfig(address: address)
+		let configDescription = config.description
 
-		Log.debug("Device Config: \(config)", component: .device)
+		Log.debug("Device Config: \(configDescription)", component: .device)
 
 		// check vendor
 		let vendor = config.vendorID

--- a/ixy/Sources/ixy/Device/Driver/Driver+Queues.swift
+++ b/ixy/Sources/ixy/Device/Driver/Driver+Queues.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 extension Driver {
-	internal func start(queue: ReceiveQueue) {
-		let index = UInt32(queue.index)
+	internal mutating func start(receiveQueue: ReceiveQueue) {
+		let index = UInt32(receiveQueue.queue.index)
 		let rxdctl = IXGBE_RXDCTL(index)
 		
 		self[rxdctl] |= IXGBE_RXDCTL_ENABLE
@@ -17,15 +17,15 @@ extension Driver {
 
 		self[IXGBE_RDH(index)] = 0
 		//self[IXGBE_RDT(index)] = UInt32(queue.descriptors.count - 1)
-		self.update(queue: queue, tailIndex: UInt32(queue.descriptors.count - 1))
+		self.update(receiveQueue: receiveQueue, tailIndex: UInt32(receiveQueue.queue.descriptors.count - 1))
 	}
 
-	func getHeadIndex(queue: ReceiveQueue) -> UInt32 {
-		return self[IXGBE_RDH(UInt32(queue.index))]
+	func getHeadIndex(receiveQueue: ReceiveQueue) -> UInt32 {
+		return self[IXGBE_RDH(UInt32(receiveQueue.queue.index))]
 	}
 
-	internal func start(queue: TransmitQueue) {
-		let index = UInt32(queue.index)
+	internal mutating func start(transmitQueue: TransmitQueue) {
+		let index = UInt32(transmitQueue.queue.index)
 
 		self[IXGBE_TDH(index)] = 0
 		self[IXGBE_TDT(index)] = 0
@@ -35,11 +35,11 @@ extension Driver {
 		wait(until: txdctl, didSetMask: IXGBE_TXDCTL_ENABLE)
 	}
 
-	internal func update(queue: ReceiveQueue, tailIndex: UInt32) {
-		self[IXGBE_RDT(UInt32(queue.index))] = tailIndex
+	internal mutating func update(receiveQueue: ReceiveQueue, tailIndex: UInt32) {
+		self[IXGBE_RDT(UInt32(receiveQueue.queue.index))] = tailIndex
 	}
 
-	internal func update(queue: TransmitQueue, tailIndex: UInt32) {
-		self[IXGBE_TDT(UInt32(queue.index))] = tailIndex
+	internal mutating func update(transmitQueue: TransmitQueue, tailIndex: UInt32) {
+		self[IXGBE_TDT(UInt32(transmitQueue.queue.index))] = tailIndex
 	}
 }

--- a/ixy/Sources/ixy/Device/Driver/Driver.swift
+++ b/ixy/Sources/ixy/Device/Driver/Driver.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// abstraction for the Intel 82599 pci interface
-class Driver {
+struct Driver {
 	internal let address: PCIAddress
 	private let resource: UnsafeMutableRawPointer
 	private let mmap: MemoryMap

--- a/ixy/Sources/ixy/Memory/DMAMemory.swift
+++ b/ixy/Sources/ixy/Memory/DMAMemory.swift
@@ -42,7 +42,7 @@ struct DMAMemory {
 }
 
 extension DMAMemory {
-	init(virtual: UnsafeMutableRawPointer, using pagemap: Pagemap) throws {
+	init(virtual: UnsafeMutableRawPointer, using pagemap: borrowing Pagemap) throws {
 		self.virtual = virtual
 		// Generate Physical
 		guard let physical = pagemap.physical(from: virtual) else { throw Error.fetchingPhysicalAddress }

--- a/ixy/Sources/ixy/Memory/DMAMempool.swift
+++ b/ixy/Sources/ixy/Memory/DMAMempool.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 /// the mempool holds references to multiple entries, which can be 'allocated' for temporary usage and 'freed' when done
-public class DMAMempool {
+public struct DMAMempool {
 	/// use a class to wrap entry data
-	class Entry {
+	struct Entry {
 		let pointer: DMAMemory
 		let size: UInt
 		fileprivate(set) var inUse: Bool = false
@@ -22,9 +22,9 @@ public class DMAMempool {
 	}
 
 	/// the mempool pointer automatically "free"s an entry when it's released
-	public class Pointer {
-		let entry: DMAMempool.Entry
-		let mempool: DMAMempool
+	public struct Pointer {
+		var entry: DMAMempool.Entry
+		var mempool: DMAMempool
 		let id: Int
 		var size: UInt16 = 0
 
@@ -36,8 +36,9 @@ public class DMAMempool {
 			self.mempool = mempool
 		}
 
-		public func free() {
-			self.mempool.freePointer(self)
+		public mutating func free() {
+			var tmpPointer = self
+			self.mempool.freePointer(&tmpPointer)
 		}
 
 		public func touch() {
@@ -80,14 +81,14 @@ public class DMAMempool {
 		self.availableEntries = self.entries
 	}
 
-	func getFreePointer() -> Pointer? {
+	mutating func getFreePointer() -> Pointer? {
 		guard self.availableEntries.count > 0 else { return nil }
-		let pointer = self.availableEntries.removeLast()
+		var pointer = self.availableEntries.removeLast()
 		pointer.entry.inUse = true
 		return pointer
 	}
 
-	fileprivate func freePointer(_ pointer: Pointer) {
+	fileprivate mutating func freePointer(_ pointer: inout Pointer) {
 		pointer.entry.inUse = false
 		self.availableEntries.append(pointer)
 	}

--- a/ixy/Sources/ixy/Memory/DMAMempool.swift
+++ b/ixy/Sources/ixy/Memory/DMAMempool.swift
@@ -95,7 +95,7 @@ public struct DMAMempool {
 }
 
 extension DMAMemory {
-	static func byConverting(virtual: UnsafeMutableRawPointer, using pagemap: Pagemap) -> DMAMemory? {
+	static func byConverting(virtual: UnsafeMutableRawPointer, using pagemap: borrowing Pagemap) -> DMAMemory? {
 		guard let physical = pagemap.physical(from: virtual) else { return nil; }
 		return DMAMemory(virtual: virtual, physical: physical)
 	}

--- a/ixy/Sources/ixy/Memory/Hugepage.swift
+++ b/ixy/Sources/ixy/Memory/Hugepage.swift
@@ -59,7 +59,7 @@ struct Hugepage {
 		return file
 	}
 
-	private static func createMemoryMap(file: File, size: Int) throws -> MemoryMap {
+	private static func createMemoryMap(file: borrowing File, size: Int) throws -> MemoryMap {
 		let memoryMap = try MemoryMap(file: file, size: size, access: .readwrite, flags: [.shared, .hugetable])
 		try memoryMap.lock()
 		return memoryMap

--- a/ixy/Sources/ixy/Memory/Hugepage.swift
+++ b/ixy/Sources/ixy/Memory/Hugepage.swift
@@ -18,7 +18,7 @@ struct Hugepage {
 		return try? DMAMemory(virtual: self.address)
 	}()
 	
-	static let pageId: Atomic<Int> = Atomic(value: 0)
+	static var pageId: Atomic<Int> = Atomic(value: 0)
 
 	enum Error: Swift.Error {
 		case contiguousMultipageNotSupported

--- a/ixy/Sources/ixy/Memory/MemoryMap.swift
+++ b/ixy/Sources/ixy/Memory/MemoryMap.swift
@@ -45,7 +45,7 @@ internal class MemoryMap {
 		munmap(self.address, self.size)
 	}
 
-	convenience init(file: File, size: Int?, access: Accessibility, flags: Flags) throws {
+	convenience init(file: borrowing File, size: Int?, access: Accessibility, flags: Flags) throws {
 		guard let path = file.path else { throw Error.invalidFile }
 		let safeSize: Int = try {
 			// use given size

--- a/ixy/Sources/ixy/Queue/Descriptor+Receive.swift
+++ b/ixy/Sources/ixy/Queue/Descriptor+Receive.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - Receiving
 extension Descriptor {
-	func prepareForReceiving() {
+	mutating func prepareForReceiving() {
 		// allocate new mempool entry if necessary
 		guard self.packetPointer == nil, let packetPointer = self.packetMempool.getFreePointer() else {
 			Log.warn("Couldn't alloc space for packet", component: .rx)
@@ -28,8 +28,8 @@ extension Descriptor {
 		case packet(DMAMempool.Pointer)
 	}
 
-	func receivePacket() -> ReceiveResponse {
-		guard let entry = self.packetPointer else {
+	mutating func receivePacket() -> ReceiveResponse {
+		guard var entry = self.packetPointer else {
 			Log.error("No packet pointer", component: .rx)
 			return .unknownError;
 		}

--- a/ixy/Sources/ixy/Queue/Descriptor+Transmit.swift
+++ b/ixy/Sources/ixy/Queue/Descriptor+Transmit.swift
@@ -12,21 +12,21 @@ extension Descriptor {
 		return /*self.packetPointer != nil &&*/ TransmitWriteback.done(queuePointer)
 	}
 
-	internal func cleanUp() {
+	internal mutating func cleanUp() {
 		self.queuePointer[0] = 0
 		self.queuePointer[1] = 0
 		self.packetPointer = nil
 	}
 
-	func cleanUpTransmitted() {
+	mutating func cleanUpTransmitted() {
 		self.queuePointer[0] = 0
 		self.queuePointer[1] = 0
-		guard let packetPointer = self.packetPointer else { Log.warn("No packet pointer", component: .tx); fatalError("oops") }
+		guard var packetPointer = self.packetPointer else { Log.warn("No packet pointer", component: .tx); fatalError("oops") }
 		packetPointer.free()
 		self.packetPointer = nil
 	}
 
-	func scheduleForTransmission(packetPointer: DMAMempool.Pointer) {
+	mutating func scheduleForTransmission(packetPointer: DMAMempool.Pointer) {
 		self.packetPointer = packetPointer
 		assert(queuePointer[0] == 0, "Queue pointer not clean!")
 		let size = UInt32(packetPointer.size)

--- a/ixy/Sources/ixy/Queue/Descriptor.swift
+++ b/ixy/Sources/ixy/Queue/Descriptor.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-class Descriptor {
+struct Descriptor {
 	internal let queuePointer: UnsafeMutablePointer<UInt64>
 	internal var packetPointer: DMAMempool.Pointer?
-	internal let packetMempool: DMAMempool
+	internal var packetMempool: DMAMempool
 
 	init(queuePointer: UnsafeMutablePointer<UInt64>, mempool: DMAMempool) {
 		self.queuePointer = queuePointer

--- a/ixy/Sources/ixy/Queue/Queue.swift
+++ b/ixy/Sources/ixy/Queue/Queue.swift
@@ -26,7 +26,7 @@ public struct Queue {
 
 		let capacity = Int(descriptorCount * 2)
 		let queuePointer = memory.address.bindMemory(to: UInt64.self, capacity: capacity)
-		queuePointer.assign(repeating: UInt64(bitPattern: -1), count: capacity)
+		queuePointer.update(repeating: UInt64(bitPattern: -1), count: capacity)
 		
 		let intDescriptorCount = Int(descriptorCount)
 		self.descriptors = (0..<intDescriptorCount).map { (Idx) -> Descriptor in

--- a/ixy/Sources/ixy/Queue/Queue.swift
+++ b/ixy/Sources/ixy/Queue/Queue.swift
@@ -39,9 +39,9 @@ public struct Queue {
 		
 	}
 
-	static func withHugepageMemory(index: UInt, packetMempool: DMAMempool, descriptorCount: UInt, driver: Driver) throws -> Self {
+	static func withHugepageMemory(index: UInt, packetMempool: DMAMempool, descriptorCount: UInt, driver: Driver) throws -> Queue {
 		let pageSize = (Int(descriptorCount) * MemoryLayout<Int64>.size * 2)
 		let hugepage = try Hugepage(size: pageSize, requireContiguous: true)
-		return try self.init(index: index, memory: hugepage.memoryMap, packetMempool: packetMempool, descriptorCount: descriptorCount, driver: driver)
+		return try Queue(index: index, memory: hugepage.memoryMap, packetMempool: packetMempool, descriptorCount: descriptorCount, driver: driver)
 	}
 }

--- a/ixy/Sources/ixy/Queue/Queue.swift
+++ b/ixy/Sources/ixy/Queue/Queue.swift
@@ -1,12 +1,12 @@
 
 /// base class for a queue
-public class Queue {
+public struct Queue {
 	private let memory: MemoryMap
-	internal let packetMempool: DMAMempool
-	internal let descriptors: [Descriptor]
+	internal var packetMempool: DMAMempool
+	internal var descriptors: [Descriptor]
 	internal var tailIndex: Int = 0
 	internal var headIndex: Int = 0
-	internal let driver: Driver
+	internal var driver: Driver
 	internal let index: UInt
 
 	internal let address: DMAMemory
@@ -16,7 +16,7 @@ public class Queue {
 		case memoryError
 	}
 
-	required init(index: UInt, memory: MemoryMap, packetMempool: DMAMempool, descriptorCount: UInt, driver: Driver) throws {
+	init(index: UInt, memory: MemoryMap, packetMempool: DMAMempool, descriptorCount: UInt, driver: Driver) throws {
 		self.memory = memory
 		self.packetMempool = packetMempool
 		self.driver = driver

--- a/ixy/Sources/ixy/Queue/TransmitQueue.swift
+++ b/ixy/Sources/ixy/Queue/TransmitQueue.swift
@@ -1,7 +1,12 @@
 
-public final class TransmitQueue: Queue {
+public struct TransmitQueue {
+	var queue : Queue
 	public var lostPackets: Int = 0
 	public var sentPackets: Int = 0
+
+	init(index: UInt, memory: MemoryMap, packetMempool: DMAMempool, descriptorCount: UInt, driver: Driver) throws {
+		try self.queue = Queue(index: index, memory: memory, packetMempool: packetMempool, descriptorCount: descriptorCount, driver: driver)
+	}
 
 	/// adds the packets to the transmit buffer
 	///
@@ -9,34 +14,34 @@ public final class TransmitQueue: Queue {
 	///   - packets: the packets to add
 	///   - freeUnused: if true, packets that can't be added will be automatically freed
 	/// - Returns: the number of added packets
-	public func transmit(_ packets: [DMAMempool.Pointer], freeUnused: Bool = true) -> Int {
+	public mutating func transmit(_ packets: inout [DMAMempool.Pointer], freeUnused: Bool = true) -> Int {
 		#if USE_BATCH_TX_CLEAN
 		cleanUpBatch()
 		#else
 		cleanUp()
 		#endif
 
-		var nextIndex: Int = tailIndex
-		let oldIndex: Int = tailIndex
+		var nextIndex: Int = self.queue.tailIndex
+		let oldIndex: Int = self.queue.tailIndex
 
 		var txCount: Int = 0
 		for packet in packets {
-			nextIndex ++< descriptors.count
-			guard nextIndex != headIndex else {
+			nextIndex ++< self.queue.descriptors.count
+			guard nextIndex != self.queue.headIndex else {
 				break
 			}
-			self.descriptors[tailIndex].scheduleForTransmission(packetPointer: packet)
+			self.queue.descriptors[self.queue.tailIndex].scheduleForTransmission(packetPointer: packet)
 			txCount += 1
-			tailIndex ++< descriptors.count
+			self.queue.tailIndex ++< self.queue.descriptors.count
 		}
 
-		if oldIndex != tailIndex {
-			self.driver.update(queue: self, tailIndex: UInt32(tailIndex))
+		if oldIndex != self.queue.tailIndex {
+			self.queue.driver.update(transmitQueue: self, tailIndex: UInt32(self.queue.tailIndex))
 		}
 
 		if freeUnused && txCount < packets.count {
 			var freed: Int = 0
-			for packet in packets[txCount..<packets.count] {
+			for var packet in packets[txCount..<packets.count] {
 				packet.free()
 				freed += 1
 			}
@@ -45,57 +50,58 @@ public final class TransmitQueue: Queue {
 		return txCount
 	}
 
-	override func start() {
-		Log.debug("Starting \(self.index)", component: .tx)
-		for descriptor in descriptors {
+	mutating func start() {
+		Log.debug("Starting \(self.queue.index)", component: .tx)
+		for var descriptor in self.queue.descriptors {
 			descriptor.cleanUp()
 		}
-		driver.start(queue: self)
+		self.queue.driver.start(transmitQueue: self)
 	}
 
-	private func cleanUp() {
+	private mutating func cleanUp() {
 		// iterate over descriptors and clean up, adjusting the head index
-		while cleanUp(descriptor: descriptors[headIndex]) {
-			headIndex ++< descriptors.count
+		var tmpDescriptor = self.queue.descriptors[self.queue.headIndex]
+		while cleanUp(descriptor: &tmpDescriptor) {
+			self.queue.headIndex ++< self.queue.descriptors.count
 		}
 	}
 
-	private func cleanUpBatch() {
+	private mutating func cleanUpBatch() {
 		while true {
-			var cleanable: Int = tailIndex - headIndex
+			var cleanable: Int = self.queue.tailIndex - self.queue.headIndex
 			if cleanable < 0 {
-				cleanable = descriptors.count + cleanable
+				cleanable = self.queue.descriptors.count + cleanable
 			}
 			if cleanable < 32 {
 				break
 			}
-			var cleanup_to: Int = headIndex + 32 - 1
-			if cleanup_to >= descriptors.count {
-				cleanup_to -= descriptors.count
+			var cleanup_to: Int = self.queue.headIndex + 32 - 1
+			if cleanup_to >= self.queue.descriptors.count {
+				cleanup_to -= self.queue.descriptors.count
 			}
 
-			if descriptors[cleanup_to].transmitted {
-				var i: Int = headIndex
+			if self.queue.descriptors[cleanup_to].transmitted {
+				var i: Int = self.queue.headIndex
 				while true {
-					descriptors[i].cleanUpTransmitted()
+					self.queue.descriptors[i].cleanUpTransmitted()
 					if i == cleanup_to {
 						break
 					}
-					i ++< descriptors.count
+					i ++< self.queue.descriptors.count
 				}
 				sentPackets += 32
 			} else {
 				break
 			}
-			headIndex = cleanup_to
-			headIndex ++< descriptors.count
+			self.queue.headIndex = cleanup_to
+			self.queue.headIndex ++< self.queue.descriptors.count
 		}
 	}
 
-	private func cleanUp(descriptor: Descriptor) -> Bool {
+	private mutating func cleanUp(descriptor: inout Descriptor) -> Bool {
 		// check if head < tail
-		guard headIndex != tailIndex else {
-			Log.debug("head \(headIndex) = tail \(tailIndex). cleanup done", component: .tx)
+		guard self.queue.headIndex != self.queue.tailIndex else {
+			Log.debug("head \(self.queue.headIndex) = tail \(self.queue.tailIndex). cleanup done", component: .tx)
 			return false
 		}
 		// check if transmitted
@@ -108,6 +114,12 @@ public final class TransmitQueue: Queue {
 		descriptor.cleanUpTransmitted()
 		sentPackets += 1
 		return true
+	}
+
+	static func withHugepageMemory(index: UInt, packetMempool: DMAMempool, descriptorCount: UInt, driver: Driver) throws -> Self {
+		let pageSize = (Int(descriptorCount) * MemoryLayout<Int64>.size * 2)
+		let hugepage = try Hugepage(size: pageSize, requireContiguous: true)
+		return try self.init(index: index, memory: hugepage.memoryMap, packetMempool: packetMempool, descriptorCount: descriptorCount, driver: driver)
 	}
 }
 
@@ -125,8 +137,8 @@ extension TransmitQueue {
 		 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		 0x00, 0x00, 0x00, 0x00]
 
-	public func createDummyPacket() -> DMAMempool.Pointer? {
-		guard let dummy = self.packetMempool.getFreePointer() else { return nil }
+	public mutating func createDummyPacket() -> DMAMempool.Pointer? {
+		guard var dummy = self.queue.packetMempool.getFreePointer() else { return nil }
 		let size = TransmitQueue.dummyPacketData.count
 		let ptr = dummy.entry.pointer.virtual
 


### PR DESCRIPTION
changed class to struct where possible in ixy project; only class MemoryMap is still class.
Maybe replacing class with struct will solve retain/release problem: "A total of 76% of the CPU time is spent incrementing and decrementing reference counters".
fixme in File.swift: deinit block commented out, so need to close(fd) somewhere else.

used Swift version 5.1-dev (LLVM b47beb8a70, Swift fcc37cda9c)
